### PR TITLE
Fix compilation issues caused by smart pointer mismatch

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -19,7 +19,6 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>rclpy</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>rslidar_input</build_depend>
   <build_depend>libpcl-all-dev</build_depend>
   <build_depend>libpcap</build_depend>
 

--- a/src/lslidar_driver.cpp
+++ b/src/lslidar_driver.cpp
@@ -528,7 +528,7 @@ namespace lslidar_driver {
                     }
                     packetType = false;
                     point_cloud_xyzirt_ = std::move(point_cloud_xyzirt_bak_);
-                    point_cloud_xyzirt_bak_ = boost::make_shared<pcl::PointCloud<VPoint>>();
+                    point_cloud_xyzirt_bak_ = pcl::make_shared<pcl::PointCloud<VPoint>>();
                 } else {
                     {
                         std::unique_lock<std::mutex> lock(pc_lock);
@@ -536,8 +536,8 @@ namespace lslidar_driver {
                     }
                     threadPool_->enqueue([&]() { publishPointCloud(); });
                     packetType = false;
-                    point_cloud_xyzirt_ = boost::make_shared<pcl::PointCloud<VPoint>>();
-                    point_cloud_xyzirt_bak_ = boost::make_shared<pcl::PointCloud<VPoint>>();
+                    point_cloud_xyzirt_ = pcl::make_shared<pcl::PointCloud<VPoint>>();
+                    point_cloud_xyzirt_bak_ = pcl::make_shared<pcl::PointCloud<VPoint>>();
                 }
             }
         }
@@ -615,7 +615,7 @@ namespace lslidar_driver {
                     }
                     packetType = false;
                     point_cloud_xyzirt_ = std::move(point_cloud_xyzirt_bak_);
-                    point_cloud_xyzirt_bak_ = boost::make_shared<pcl::PointCloud<VPoint>>();
+                    point_cloud_xyzirt_bak_ = pcl::make_shared<pcl::PointCloud<VPoint>>();
                 } else {
                     {
                         std::unique_lock<std::mutex> lock(pc_lock);
@@ -623,8 +623,8 @@ namespace lslidar_driver {
                     }
                     threadPool_->enqueue([&]() { publishPointCloud(); });
                     packetType = false;
-                    point_cloud_xyzirt_ = boost::make_shared<pcl::PointCloud<VPoint>>();
-                    point_cloud_xyzirt_bak_ = boost::make_shared<pcl::PointCloud<VPoint>>();
+                    point_cloud_xyzirt_ = pcl::make_shared<pcl::PointCloud<VPoint>>();
+                    point_cloud_xyzirt_bak_ = pcl::make_shared<pcl::PointCloud<VPoint>>();
                 }
             }
         }


### PR DESCRIPTION
This PR fixes the compilation of the LS-S1 branch caused by the mismatch between `boost::make_shared` and `pcl::make_shared`. This is required because `pcl` is using standard smart pointers and not `boost` since [version 1.11.0 ](https://github.com/PointCloudLibrary/pcl/releases/tag/pcl-1.11.0).